### PR TITLE
Fix the git command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In both cases, the trigger word must be the first word in the message. It is not
 1. Download stockbot
 
   ````
-  git https://github.com/NosajGithub/stock-quote-slackbot.git
+  git clone https://github.com/NosajGithub/stock-quote-slackbot.git stock-quote-slackbot
   cd stock-quote-slackbot
   ````
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In both cases, the trigger word must be the first word in the message. It is not
  Also, pick a trigger word in the rtmbot.conf file.
 
   ````
-  cp example-config/rtmbot.conf .
+  cp rtmbot.conf.example rtmbot.conf .
   vi rtmbot.conf
   SLACK_TOKEN: "xoxb-11111111111-222222222222222"
   TRIGGER_WORD: "quote"


### PR DESCRIPTION
The git command was missing the 'clone' argument.
